### PR TITLE
Delay initialization

### DIFF
--- a/src/main/java/fiji/DefaultFijiService.java
+++ b/src/main/java/fiji/DefaultFijiService.java
@@ -39,6 +39,7 @@ public class DefaultFijiService extends AbstractService implements FijiService {
 		final ImageJ ij = IJ.getInstance();
 		if (ij != null) {
 			new Thread() {
+				@Override
 				public void run() {
 					/*
 					 * Do not run updater when command line

--- a/src/main/java/fiji/DefaultFijiService.java
+++ b/src/main/java/fiji/DefaultFijiService.java
@@ -33,10 +33,10 @@ public class DefaultFijiService extends AbstractService implements FijiService {
 		FileDialogDecorator.registerAutomaticDecorator();
 		JFileChooserDecorator.registerAutomaticDecorator();
 		setAWTAppClassName(Main.class);
-		runPlugInGently("fiji.util.RedirectErrAndOut", null);
-		new MenuRefresher().run();
 		final ImageJ ij = IJ.getInstance();
 		if (ij != null) {
+			runPlugInGently("fiji.util.RedirectErrAndOut", null);
+			new MenuRefresher().run();
 			new Thread() {
 				@Override
 				public void run() {

--- a/src/main/java/fiji/DefaultFijiService.java
+++ b/src/main/java/fiji/DefaultFijiService.java
@@ -11,9 +11,11 @@ import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 import java.lang.reflect.Field;
 
+import org.scijava.event.EventHandler;
 import org.scijava.plugin.Plugin;
 import org.scijava.service.AbstractService;
 import org.scijava.service.Service;
+import org.scijava.service.event.ServicesLoadedEvent;
 
 /**
  * The default initializer for the Fiji legacy application.
@@ -28,8 +30,7 @@ import org.scijava.service.Service;
 @Plugin(type = Service.class)
 public class DefaultFijiService extends AbstractService implements FijiService {
 
-	@Override
-	public void initialize() {
+	public void actuallyInitialize() {
 		FileDialogDecorator.registerAutomaticDecorator();
 		JFileChooserDecorator.registerAutomaticDecorator();
 		setAWTAppClassName(Main.class);
@@ -56,6 +57,11 @@ public class DefaultFijiService extends AbstractService implements FijiService {
 			}.start();
 			new IJ_Alt_Key_Listener().run();
 		}
+	}
+
+	@EventHandler
+	protected void onEvent(@SuppressWarnings("unused") ServicesLoadedEvent evt) {
+		actuallyInitialize();
 	}
 
 	private static boolean setAWTAppClassName(Class<?> appClass) {

--- a/src/main/java/fiji/DefaultFijiService.java
+++ b/src/main/java/fiji/DefaultFijiService.java
@@ -2,6 +2,8 @@ package fiji;
 
 import static fiji.FijiTools.runPlugInGently;
 import static fiji.FijiTools.runUpdater;
+import fiji.gui.FileDialogDecorator;
+import fiji.gui.JFileChooserDecorator;
 import ij.IJ;
 import ij.ImageJ;
 
@@ -12,9 +14,6 @@ import java.lang.reflect.Field;
 import org.scijava.plugin.Plugin;
 import org.scijava.service.AbstractService;
 import org.scijava.service.Service;
-
-import fiji.gui.FileDialogDecorator;
-import fiji.gui.JFileChooserDecorator;
 
 /**
  * The default initializer for the Fiji legacy application.


### PR DESCRIPTION
We want to delay initialization of the `DefaultFijiService` until _after_ the `LegacyService` has initialized (and hence set up ImageJ1 as desired, including patches). But we cannot add a direct dependency on `LegacyService` via the usual `@Parameter` mechanism because that would hose the class loading process. So let's make `DefaultFijiService` initialize itself very late in the game.
